### PR TITLE
Catch Errors

### DIFF
--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -101,7 +101,7 @@ export default Ember.Component.extend({
               }, (err) => {
                 set(this, 'isSubmitting', false);
                 return get(this, 'onError')(err);
-              })
+              });
           }
         })
         .finally(() => {


### PR DESCRIPTION
Since we are using a static Promise we have to apply [Static Promise Syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve#Using_the_static_Promise.resolve_method) to catch any errors
