### PR TITLE
(WIP) Make OSS-worthy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 ---
+sudo: required
+dist: trusty
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+
 language: node_js
 node_js:
   - "4"
-
-sudo: false
 
 cache:
   directories:
@@ -11,7 +18,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.3
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ before_install:
   - npm config set spin false
   - npm install -g bower
   - bower --version
-  - npm install phantomjs-prebuilt
-  - phantomjs --version
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 install:
   - npm install

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at code-of-conduct@frontside.io. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Emberx-form
+# emberx-form
 
-This README outlines the details of collaborating on this Ember addon.
+<Sweet Tagline Here>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ This README outlines the details of collaborating on this Ember addon.
 * `ember build`
 
 For more information on using ember-cli, visit [http://ember-cli.com/](http://ember-cli.com/).
+
+Code of Conduct
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms, which can be found in the CODE_OF_CONDUCT.md file in this repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # emberx-form
+[![npm version](https://badge.fury.io/js/emberx-form.svg)](http://badge.fury.io/js/emberx-form)
+[![Build Status](https://travis-ci.org/thefrontside/emberx-form.svg?branch=master)](https://travis-ci.org/thefrontside/emberx-form)
 
 <Sweet Tagline Here>
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,14 +7,25 @@ module.exports = {
         dependencies: { }
       }
     },
+    // {
+    //   name: 'ember-1.13',
+    //   bower: {
+    //     dependencies: {
+    //       'ember': '~1.13.0'
+    //     },
+    //     resolutions: {
+    //       'ember': '~1.13.0'
+    //     }
+    //   }
+    // },
     {
-      name: 'ember-1.13',
+      name: 'ember-2.3',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': '~2.3.0'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': '~2.3.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emberx-form",
   "version": "0.0.1-alpha",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "A set of components for building dynamic forms. Built on top of ember-changeset.",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,11 +11,10 @@
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "",
+  "repository": "https://github.com/thefrontside/emberx-form",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
@@ -42,11 +41,17 @@
     "loader.js": "^4.0.1"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "ember",
+    "form",
+    "component",
+    "emberx-form",
+    "x-form",
+    "changeset"
   ],
   "dependencies": {
     "ember-changeset": "0.13.3",
-    "ember-changeset-validations": "0.9.2",
+    "ember-changeset-validations": "^0.9.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-truth-helpers": "1.2.0"

--- a/testem.js
+++ b/testem.js
@@ -1,7 +1,7 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
+  "framework": "mocha",
+  "test_page": "tests/index.html",
   "disable_watching": true,
   "launch_in_ci": [
     "Chrome"


### PR DESCRIPTION
Whoooooo, `emberx-form` getting its first glimpse of the real world.

Starting the process of getting this thing up to our OSS standards. Updated the `ember-try` config to test against Ember 2.3 or higher (since hash helpers and contextual components are problematic before that), and added some of our basic OSS things (like the code of conduct, repo URL).

Lots more to do, but this is the first step.