### PR TITLE
Update ember-changeset-validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "changeset"
   ],
   "dependencies": {
-    "ember-changeset": "^1.0.0",
-    "ember-changeset-validations": "^1.0.0",
+    "ember-changeset-validations": "^1.0.2",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-truth-helpers": "1.2.0"


### PR DESCRIPTION
Remove ember-changeset. ECV automatically brings the correct version in.