### PR TITLE
Added a value property to the page object that actually works

### DIFF
--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -48,6 +48,10 @@ describe('Acceptance: PeopleForm', function() {
         people.form.lastName.fillInAndBlur('f');
       });
 
+      it('has a value in first name', function() {
+        expect(people.form.firstName.value).to.equal('c');
+      });
+
       it('still has a disabled submit button', function() {
         expect(people.form.submitButton.isDisabled).to.be.true;
       });
@@ -74,6 +78,10 @@ describe('Acceptance: PeopleForm', function() {
         people.form.firstName.fillInAndBlur('john');
         people.form.lastName.fillInAndBlur('smith');
         people.form.favoriteBand.selectAndBlur('Shellac');
+      });
+
+      it('has the correct value', function() {
+        expect(people.form.firstName.value).to.equal('john');
       });
 
       it('enables the submit button', function() {

--- a/tests/pages/people.js
+++ b/tests/pages/people.js
@@ -7,7 +7,8 @@ import {
   hasClass,
   is,
   collection,
-  text
+  value,
+  text,
 } from 'ember-cli-page-object';
 
 // Make a basic page object component and merge in options
@@ -36,6 +37,8 @@ const makeButton = (selector) => {
 const makeField = (fieldSelector, inputSelector, [name, action]) => {
   let options = {
     hasErrors: hasClass('has-error'),
+
+    value: value(inputSelector),
 
     [name]: action(inputSelector),
     blur: triggerable('blur', inputSelector),


### PR DESCRIPTION
The `makeField` page object helper wasn't *actually* creating a `value` property on the field component objects, and as a result there wasn't actually any way to test (for instance) `firstName.value`.

To address this, I've added a property to the helper's config object that calculates value using the `inputSelector` argument.