### PR TITLE
Make changeset computed property

### DIFF
--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -4,7 +4,7 @@ import lookupValidator from 'ember-changeset-validations';
 import applyChangeset from '../utils/apply-changeset';
 import layout from '../templates/components/x-field';
 
-const { get, set, RSVP } = Ember;
+const { computed, get, set, RSVP } = Ember;
 
 
 /**
@@ -71,18 +71,20 @@ export default Ember.Component.extend({
 
   init() {
     this._super(...arguments);
-    this._setUpChangeset();
+    if(!this.get('data')) {
+      throw new Error('x-form needs data');
+    }
   },
 
-  _setUpChangeset() {
+  changeset: computed('data', 'validations', function() {
     let validations = this.get('validations') ? this.get('validations') : {};
 
-    set(this, 'changeset', new Changeset(
+    return new Changeset(
       this.get('data'),
       lookupValidator(validations),
       validations
-    ));
-  },
+    );
+  }),
 
   actions: {
     /**
@@ -122,7 +124,7 @@ export default Ember.Component.extend({
           }
         })
         .finally(() => {
-          this._setUpChangeset();
+          set(this, 'validations', Object.assign({}, get(this, 'validations')));
           set(this, 'isSubmitting', false);
         });
     },

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -34,7 +34,7 @@ describe('Acceptance: PeopleForm', function() {
 
     it('contains the list and has the correct length', function() {
       expect(people.list().isVisible).to.be.true;
-      expect(people.list().count, 'There should only be one person in the list').to.equal(1);
+      expect(people.list().count, 'There should be two people in the list').to.equal(2);
     });
 
     it('starts with a disabled submit button', function() {
@@ -100,12 +100,12 @@ describe('Acceptance: PeopleForm', function() {
         });
 
         it('adds a new person to the list', function() {
-          expect(people.list().count).to.equal(2);
+          expect(people.list().count).to.equal(3);
         });
 
         it('creates a new person with the correct information', function() {
-          expect(people.list(1).name).to.equal('john smith');
-          expect(people.list(1).favoriteBand).to.equal('Favorite Band: Shellac');
+          expect(people.list(2).name).to.equal('john smith');
+          expect(people.list(2).favoriteBand).to.equal('Favorite Band: Shellac');
         });
       });
     });

--- a/tests/acceptance/route-transition-test.js
+++ b/tests/acceptance/route-transition-test.js
@@ -1,0 +1,74 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+import routeTransitionForm from '../pages/route-transition-form';
+
+describe('Acceptance: RouteTransition', function() {
+  let application;
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    destroyApp(application);
+  });
+
+  describe('visiting a page with a form component', function() {
+    beforeEach(function() {
+      routeTransitionForm.visit();
+      routeTransitionForm.selectFirstEditForm();
+    });
+
+    it('contains the form', function() {
+      expect(currentURL()).to.equal('/route-transitions/1');
+      expect(routeTransitionForm.form.isVisible).to.be.true;
+    });
+
+    it('displays the existing data in the form', function() {
+      expect(routeTransitionForm.form.firstName.value).to.equal('Robert');
+      expect(routeTransitionForm.form.lastName.value).to.equal('Smith');
+    });
+
+    describe('clicking to go to another page with the same component', function() {
+      beforeEach(function() {
+        routeTransitionForm.selectSecondEditForm();
+      });
+
+      it('updates the data in the form to reflect the new route', function() {
+        expect(routeTransitionForm.form.firstName.value).to.equal('Brendan');
+        expect(routeTransitionForm.form.lastName.value).to.equal('Canning');
+      });
+
+      describe('selecting a route where a new model will be created with the same component', function() {
+        beforeEach(function() {
+          routeTransitionForm.selectCreateForm();
+        });
+
+        it('clears the data out of the form', function() {
+          expect(routeTransitionForm.form.firstName.value).to.equal('');
+          expect(routeTransitionForm.form.lastName.value).to.equal('');
+        });
+      });
+
+      describe('returning to the original page', function() {
+        beforeEach(function() {
+          routeTransitionForm.selectFirstEditForm();
+        });
+
+        it('updates the data in the form to reflect the new route', function() {
+          expect(routeTransitionForm.form.firstName.value).to.equal('Robert');
+          expect(routeTransitionForm.form.lastName.value).to.equal('Smith');
+        });
+      });
+    });
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,10 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('reset-changeset');
+  this.route('route-transitions', function() {
+    this.route('new');
+    this.route('edit', { path: '/:person_id' });
+  });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/route-transitions/edit.js
+++ b/tests/dummy/app/routes/route-transitions/edit.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(params) {
+    return this.store.findRecord('person', params.person_id);
+  }
+});

--- a/tests/dummy/app/routes/route-transitions/new.js
+++ b/tests/dummy/app/routes/route-transitions/new.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    return this.store.createRecord('person');
+  }
+});

--- a/tests/dummy/app/templates/route-transitions.hbs
+++ b/tests/dummy/app/templates/route-transitions.hbs
@@ -1,0 +1,9 @@
+<div class="container">
+  <h1>Route Transitions Test</h1>
+  <ul>
+    <li>{{#link-to 'route-transitions.edit' 1 class='test-first-edit-form'}}ID 1{{/link-to}}</li>
+    <li>{{#link-to 'route-transitions.edit' 2 class='test-second-edit-form'}}ID 2{{/link-to}}</li>
+    <li>{{#link-to 'route-transitions.new' class='test-create-form'}}New{{/link-to}}</li>
+  </ul>
+  {{outlet}}
+</div>

--- a/tests/dummy/app/templates/route-transitions/edit.hbs
+++ b/tests/dummy/app/templates/route-transitions/edit.hbs
@@ -1,0 +1,3 @@
+{{my-form
+  data=model
+}}

--- a/tests/dummy/app/templates/route-transitions/new.hbs
+++ b/tests/dummy/app/templates/route-transitions/new.hbs
@@ -1,0 +1,3 @@
+{{my-form
+  data=model
+}}

--- a/tests/dummy/mirage/fixtures/people.js
+++ b/tests/dummy/mirage/fixtures/people.js
@@ -4,5 +4,11 @@ export default [
     lastName: 'Smith',
     birthday: new Date(1990, 10, 10),
     favoriteBand: 'Dinosaur Jr.'
+  },
+  {
+    firstName: 'Brendan',
+    lastName: 'Canning',
+    birthday: new Date(1976, 9, 4),
+    favoriteBand: 'Sonic Youth'
   }
 ]

--- a/tests/pages/route-transition-form.js
+++ b/tests/pages/route-transition-form.js
@@ -1,0 +1,24 @@
+import {
+  create,
+  clickable,
+  fillable,
+  selectable,
+  visitable,
+} from 'ember-cli-page-object';
+
+import makeField from '../helpers/make-field';
+
+export default create({
+  visit: visitable('/route-transitions'),
+  selectFirstEditForm: clickable('.test-first-edit-form'),
+  selectSecondEditForm: clickable('.test-second-edit-form'),
+  selectCreateForm: clickable('.test-create-form'),
+
+  form: {
+    scope: '#test-form',
+
+    firstName: makeField('[data-test-first-name]', '#form-first-name', ['fillIn', fillable]),
+    lastName: makeField('[data-test-last-name]', '#form-last-name', ['fillIn', fillable]),
+    favoriteBand: makeField('[data-test-favorite-band]', '#form-favorite-band', ['select', selectable])
+  }
+});


### PR DESCRIPTION
### Problem

I have a two-column layout where selecting an item from the list in the left column opens an `x-form` to edit that item in the right column.

If I click an item on the left, I successfully get a form with the right data from that model.

If I click a second (or third, fourth, etc.) item on the left, the `x-field`s within my `x-form` don't update to reflect the new model passed in. They stick on the values of the original model selected.

### Proposed Solution

Compute the changeset anytime `data` or `validations` changes.

Alternative solution to https://github.com/thefrontside/emberx-form/pull/16