### PR TITLE
actually import the right template inside x-form.js

### DIFF
--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
 import applyChangeset from '../utils/apply-changeset';
-import layout from '../templates/components/x-field';
+import layout from '../templates/components/x-form';
 
 const { computed, get, set, RSVP } = Ember;
 


### PR DESCRIPTION
lol whoops...

Luckily I think the imports in the `app` folder were overriding this, so nothing ever broke, but this should probably be fixed just for sanity's sake.