### PR TITLE
Upgrade ember-truth-helpers to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-one-way-controls": "^1.1.1",
     "ember-resolver": "^2.0.3",
-    "ember-truth-helpers": "1.2.0",
+    "ember-truth-helpers": "^1.3.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
Apps using `yarn` get this message:
`warning ember-truth-helpers@1.2.0: The engine "ember-cli-app-version" appears to be invalid.`

It's been fixed in `ember-truth-helpers` 1.3.0.