### PR TITLE
Expose `form.isDirty` by tracking dirtiness in the form

### DIFF
--- a/addon/components/x-field.js
+++ b/addon/components/x-field.js
@@ -2,5 +2,15 @@ import Ember from 'ember';
 import layout from '../templates/components/x-field';
 
 export default Ember.Component.extend({
-  layout
+  layout,
+  actions: {
+    set(value) {
+      let key = this.get('property');
+      this.get('form').setField(key, value)
+    },
+    validate() {
+      // NB this will write to the changeset
+      return this.get('form.changeset').validate();
+    },
+  }
 });

--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -23,6 +23,9 @@ export default Ember.Component.extend({
 
   tagName: 'form',
 
+  isPristine: true,
+  isDirty: false,
+
   /**
    * @property data - provides the initial values of the form fields
    * @type {Object}

--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -79,6 +79,7 @@ export default Ember.Component.extend({
   changeset: computed('data', 'validations', function() {
     let validations = this.get('validations') ? this.get('validations') : {};
 
+    console.log("OH HEY");
     return new Changeset(
       this.get('data'),
       lookupValidator(validations),

--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -89,15 +89,9 @@ export default Ember.Component.extend({
     this.get('changeset').set(key, value);
   },
 
-  debugBuffer: Ember.computed(function() {
-    console.log(this.get('buffer'));
-  }),
-
-
   changeset: computed('data', 'validations', function() {
     let validations = this.get('validations') ? this.get('validations') : {};
 
-    console.log("OH HEY");
     return new Changeset(
       this.get('data'),
       lookupValidator(validations),
@@ -119,7 +113,6 @@ export default Ember.Component.extend({
      * @return {Promise}
      */
     validateProperty(changeset, prop) {
-      console.log('validateProperty')
       return changeset.validate(prop);
     },
 

--- a/addon/templates/components/x-field.hbs
+++ b/addon/templates/components/x-field.hbs
@@ -2,6 +2,8 @@
   (hash
     value=(get changeset property)
     errors=(get changeset.error property)
+    set=(action "set")
+    validate=(action "validate")
     actions=(hash
       onChange=(action (mut (get changeset property)))
       onBlur=(action validate property)

--- a/addon/templates/components/x-form.hbs
+++ b/addon/templates/components/x-form.hbs
@@ -6,6 +6,8 @@
       validate=(action 'validateProperty' changeset)
     )
     isSubmitting=isSubmitting
+    isDirty=isDirty
+    isPristine=isPristine
     isInvalid=changeset.isInvalid
     isUnsubmittable=(or changeset.isPristine changeset.isInvalid isSubmitting)
     actions=(hash

--- a/addon/templates/components/x-form.hbs
+++ b/addon/templates/components/x-form.hbs
@@ -4,6 +4,7 @@
     field=(component "x-field"
       changeset=changeset
       validate=(action 'validateProperty' changeset)
+      form=this
     )
     isSubmitting=isSubmitting
     isDirty=isDirty

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "changeset"
   ],
   "dependencies": {
-    "ember-changeset-validations": "^1.2.0",
+    "ember-changeset-validations": "^1.2.2",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-truth-helpers": "^1.3.0"

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -59,7 +59,7 @@ describe('Acceptance: PeopleForm', function() {
       });
 
       it('indicates the form is dirty and not pristine', function() {
-        expect(people.form.isDirty).to.equal(true, 'Should not dirty');
+        expect(people.form.isDirty).to.equal(true, 'Should be dirty');
         expect(people.form.isPristine).to.equal(false, 'Should not pristine');
       });
 

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -22,9 +22,14 @@ describe('Acceptance: PeopleForm', function() {
     destroyApp(application);
   });
 
-  describe('visiting the people form page', function() {
+  describe.only('visiting the people form page', function() {
     beforeEach(function() {
       people.visit();
+    });
+
+    it('starts out as pristine and not dirty', function() {
+      expect(people.form.isDirty).to.equal(false, 'Should be not dirty');
+      expect(people.form.isPristine).to.equal(true, 'Should be pristine');
     });
 
     it('contains the form', function() {
@@ -52,6 +57,11 @@ describe('Acceptance: PeopleForm', function() {
         expect(people.form.firstName.value).to.equal('c');
       });
 
+      it('indicates the form is dirty and not pristine', function() {
+        expect(people.form.isDirty).to.equal(true, 'Should not dirty');
+        expect(people.form.isPristine).to.equal(false, 'Should not pristine');
+      });
+
       it('still has a disabled submit button', function() {
         expect(people.form.submitButton.isDisabled).to.be.true;
       });
@@ -59,6 +69,11 @@ describe('Acceptance: PeopleForm', function() {
       it('has errors', function() {
         expect(people.form.firstName.hasErrors).to.be.true;
         expect(people.form.lastName.hasErrors).to.be.true;
+
+        it('is dirty', function() {
+          expect(people.form.isDirty).to.equal(true, 'Should not dirty');
+          expect(people.form.isPristine).to.equal(false, 'Should not pristine');
+        });
       });
 
       describe('clicking cancel', function() {
@@ -69,6 +84,11 @@ describe('Acceptance: PeopleForm', function() {
         it('rolls back to an empty state', function() {
           expect(people.form.firstName.value).to.equal('');
           expect(people.form.lastName.value).to.equal('');
+        });
+
+        it('ends up pristine and not dirty', function() {
+          expect(people.form.isDirty).to.equal(false, 'Should be not dirty');
+          expect(people.form.isPristine).to.equal(true, 'Should be pristine');
         });
       });
     });
@@ -106,6 +126,11 @@ describe('Acceptance: PeopleForm', function() {
         it('creates a new person with the correct information', function() {
           expect(people.list(2).name).to.equal('john smith');
           expect(people.list(2).favoriteBand).to.equal('Favorite Band: Shellac');
+        });
+
+        it('ends up pristine and not dirty', function() {
+          expect(people.form.isDirty).to.equal(false, 'Should be not dirty');
+          expect(people.form.isPristine).to.equal(true, 'Should be pristine');
         });
       });
     });

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -28,6 +28,7 @@ describe('Acceptance: PeopleForm', function() {
     });
 
     it('starts out as pristine and not dirty', function() {
+      debugger;
       expect(people.form.isDirty).to.equal(false, 'Should be not dirty');
       expect(people.form.isPristine).to.equal(true, 'Should be pristine');
     });

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -22,13 +22,12 @@ describe('Acceptance: PeopleForm', function() {
     destroyApp(application);
   });
 
-  describe.only('visiting the people form page', function() {
+  describe('visiting the people form page', function() {
     beforeEach(function() {
       people.visit();
     });
 
     it('starts out as pristine and not dirty', function() {
-      debugger;
       expect(people.form.isDirty).to.equal(false, 'Should be not dirty');
       expect(people.form.isPristine).to.equal(true, 'Should be pristine');
     });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,7 +13,9 @@
         onCancel=(action 'cancel') as |form|
       }}
         {{#form.field property="firstName" as |field|}}
-          <div data-test-first-name data-test-is-pristine={{form.isPristine}}
+          <div data-test-first-name
+               data-test-is-pristine={{form.isPristine}}
+               data-test-is-dirty={{form.isDirty}}
                class={{concat "form-group" (if field.errors.validation " has-error")}}>
 
             <h3>First Name</h3>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,7 +13,9 @@
         onCancel=(action 'cancel') as |form|
       }}
         {{#form.field property="firstName" as |field|}}
-          <div data-test-first-name class={{concat "form-group" (if field.errors.validation " has-error")}}>
+          <div data-test-first-name data-test-is-pristine={{form.isPristine}}
+               class={{concat "form-group" (if field.errors.validation " has-error")}}>
+
             <h3>First Name</h3>
               {{#each field.errors as |error|}}
                 {{error}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,5 +1,5 @@
 <div class="container">
-  <h2>Welcome to EmberX-Form!</h2>
+  <h2>Welcome to EmberX-Form! Yo!</h2>
   <div class="row">
     <div class="col-xs-6">
       {{#x-form
@@ -12,6 +12,9 @@
         onError=(action 'onError')
         onCancel=(action 'cancel') as |form|
       }}
+        <div>isDirty? {{form.isDirty}}</div>
+        <div>form.changeset.isDirty? {{form.changeset.isDirty}}</div>
+
         {{#form.field property="firstName" as |field|}}
           <div data-test-first-name
                data-test-is-pristine={{form.isPristine}}
@@ -26,8 +29,8 @@
                 class="form-control"
                 id="form-first-name"
                 value=field.value
-                update=field.actions.onChange
-                onBlur=field.actions.onBlur
+                update=field.set
+                onBlur=field.validate
               }}
           </div>
         {{/form.field}}

--- a/tests/pages/people.js
+++ b/tests/pages/people.js
@@ -2,6 +2,8 @@ import {
   create,
   visitable,
   fillable,
+  hasClass,
+  is,
   selectable,
   collection,
   text,
@@ -21,7 +23,12 @@ export default create({
     favoriteBand: makeField('[data-test-favorite-band]', '#form-favorite-band', ['select', selectable]),
 
     submitButton: makeButton('[data-test-submit-button]'),
-    cancelButton: makeButton('[data-test-cancel-button]')
+    cancelButton: makeButton('[data-test-cancel-button]'),
+
+    isPristine: is('[data-test-is-pristine=true]'),
+    get isDirty() {
+      return !this.isPristine;
+    }
   },
 
   list: collection({

--- a/tests/pages/people.js
+++ b/tests/pages/people.js
@@ -1,9 +1,11 @@
 import {
+  attribute,
   create,
   visitable,
   fillable,
   hasClass,
   is,
+  isVisible,
   selectable,
   collection,
   text,
@@ -25,10 +27,8 @@ export default create({
     submitButton: makeButton('[data-test-submit-button]'),
     cancelButton: makeButton('[data-test-cancel-button]'),
 
-    isPristine: is('[data-test-is-pristine=true]'),
-    get isDirty() {
-      return !this.isPristine;
-    }
+    isPristine: isVisible('[data-test-is-pristine]'),
+    isDirty: isVisible('[data-test-is-dirty]'),
   },
 
   list: collection({

--- a/tests/pages/people.js
+++ b/tests/pages/people.js
@@ -1,10 +1,7 @@
 import {
-  attribute,
   create,
   visitable,
   fillable,
-  hasClass,
-  is,
   isVisible,
   selectable,
   collection,


### PR DESCRIPTION
Fixes Issue #22 but it's not ready for review yet. 

Before merging:
- [ ] Simplify the tracking of changes in the form to be just boolean whether it is dirty or not. 
- [ ] Rebase and squash
- [ ] Validate that this really meets the need in the application