### PR TITLE
Change error handling to maintain input values

### DIFF
--- a/addon/components/x-form.js
+++ b/addon/components/x-form.js
@@ -119,6 +119,7 @@ export default Ember.Component.extend({
             return RSVP.resolve(submission)
               .then((record) => {
                 set(this, 'isSubmitting', false);
+                set(this, 'validations', Object.assign({}, get(this, 'validations')));
                 return get(this, 'onSuccess')(record);
               }, (err) => {
                 set(this, 'isSubmitting', false);
@@ -127,7 +128,6 @@ export default Ember.Component.extend({
           }
         })
         .finally(() => {
-          set(this, 'validations', Object.assign({}, get(this, 'validations')));
           set(this, 'isSubmitting', false);
         });
     },

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
   env: {
     embertest: true
+  },
+
+  globals: {
+    'server': 1
   }
 };

--- a/tests/acceptance/people-form-test.js
+++ b/tests/acceptance/people-form-test.js
@@ -105,7 +105,7 @@ describe('Acceptance: PeopleForm', function() {
         });
       });
 
-      describe('submitting the form', function() {
+      describe('submitting the form successfully', function() {
         beforeEach(function() {
           people.form.submitButton.click();
         });
@@ -117,6 +117,22 @@ describe('Acceptance: PeopleForm', function() {
         it('creates a new person with the correct information', function() {
           expect(people.list(2).name).to.equal('john smith');
           expect(people.list(2).favoriteBand).to.equal('Favorite Band: Shellac');
+        });
+      });
+
+      describe('submitting the form unsuccessfully', function() {
+        beforeEach(function() {
+          server.post(`/people`, {}, 500);
+          people.form.submitButton.click();
+        });
+
+        it('does not add a new person to the list', function() {
+          expect(people.list().count).to.equal(2);
+        });
+
+        it('retains the edited information in the form', function() {
+          expect(people.form.firstName.value).to.equal('john');
+          expect(people.form.lastName.value).to.equal('smith');
         });
       });
     });

--- a/tests/acceptance/person-form-test.js
+++ b/tests/acceptance/person-form-test.js
@@ -68,7 +68,7 @@ describe('Acceptance: PersonForm', function() {
         });
       });
 
-      describe('clicking save', function() {
+      describe('successfully clicking save', function() {
         beforeEach(function() {
           person.form.submitButton.click();
         });
@@ -76,6 +76,23 @@ describe('Acceptance: PersonForm', function() {
         it('hides the save and cancel buttons', function() {
           expect(person.form.cancelButton.isVisible).to.be.false;
           expect(person.form.submitButton.isVisible).to.be.false;
+        });
+
+        it('retains the edited information in the form', function() {
+          expect(person.form.firstName.value).to.equal('Carlos');
+          expect(person.form.lastName.value).to.equal('Correa');
+        });
+      });
+
+      describe('clicking save, but the save fails', function() {
+        beforeEach(function() {
+          server.patch(`/people/:id`, {}, 500);
+          person.form.submitButton.click();
+        });
+
+        it('does not hide the save and cancel buttons', function() {
+          expect(person.form.cancelButton.isVisible).to.be.true;
+          expect(person.form.submitButton.isVisible).to.be.true;
         });
 
         it('retains the edited information in the form', function() {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -12,16 +12,20 @@ export default Ember.Controller.extend({
   actions: {
     save(data) {
       console.log('saving');
-      return this.store.createRecord('person', data);
+      let person = this.store.createRecord('person', data);
+
+      return person.save().catch((err) => {
+        person.rollbackAttributes();
+        throw err;
+      })
     },
 
     onError(err) {
-      throw new Error(err);
+      console.log('error', err);
     },
 
-    onSuccess(record) {
+    onSuccess() {
       console.log('succeeded!');
-      record.save();
     },
 
     cancel() {


### PR DESCRIPTION
I ran into an inconvenient behavior when a server error would cause form submission to fail - my inputs would clear out :(

Desired behavior: when a form submission fails, maintain the values the user input into the form.